### PR TITLE
Feature/wall time

### DIFF
--- a/hash3_code.h
+++ b/hash3_code.h
@@ -2,7 +2,7 @@
 #define HASH3_CODE_H_INCLUDED
 
 //defined by us
-#define MAX_EMPTY_SLOT_NOT_FOUND 1000
+#define MAX_EMPTY_SLOT_NOT_FOUND 10000
 
 
 

--- a/vow_with_hash.c
+++ b/vow_with_hash.c
@@ -5,12 +5,14 @@
 #include <prho_vow.h>
 #include <hash3_code.h>
 #include <string.h>
+#include <time.h>
+#include <sys/time.h>
 
 
 // Defines that the user can control
 #define MAX_RUNS                    30
 #define NUM_WORKERS                 200
-#define MODULO_NUM_BITS             16
+#define MODULO_NUM_BITS             20
 
 // defined by us 
 #define NUM_THREADS                 198
@@ -44,9 +46,16 @@ IT_POINT_SET itPsets[NUM_THREADS];
 // Utility Functions
 //
 ////////////////////////////////////////////////////////////////////////////
+//
+
+
 
 double get_wall_time(){
-    return 10.0;
+    struct timeval time;
+    if (gettimeofday(&time,NULL)){
+        return 0;
+    }
+    return (double)time.tv_sec + (double)time.tv_usec * .000001;
 }
 
 void printP(POINT_T X)  {
@@ -891,10 +900,10 @@ int main()
         srand(time(NULL));
 
         // Start counting the setup time
-        start = 0;// get_wall_time();
+        start = get_wall_time();
 
         // Calculate the iteration point set base (randomly)
-        //rand_itpset(&itPsetBase, Psums, Qsums, id, a, p, maxorder, L, nbits, algorithm);
+        rand_itpset(&itPsetBase, Psums, Qsums, id, a, p, maxorder, L, nbits, algorithm);
 
         // Set up the running environment for the search for all workers
         printf("Run[%3d] setup:    ", run);
@@ -907,7 +916,8 @@ int main()
 
         // Stop counting the setup time and calculate it
         end = get_wall_time();
-        setup_time = 1000*(double)((end - start) / CLOCKS_PER_SEC);
+
+        setup_time = ((double)(end - start));
 
         // Start counting the execution time
         start = get_wall_time();
@@ -942,7 +952,7 @@ int main()
 
         // Recover the current time and calculate the execution time
         end = get_wall_time();
-        convergence_time = 1000*(double)((end - start) / CLOCKS_PER_SEC);
+        convergence_time = ((double)(end - start));
 
         // Choose text for describing the algorithm iteration point sets
         char *stepdef;


### PR DESCRIPTION
Adaptei a função get_wall_time para linux. Não fica muito caro que o calculo que o linux faz também é usando hight resolution timestamps porém o erro de relógio provavelmente não irá gerar uma disparidade tão grande nesse contexto. 

Também transformei a função check_slot_and_store em uma função critica. No momento parece ser a solução mais fácil que temos, talvez exista uma força de tornar as regiões dos vetores independentemente criticas porém não tenho certeza de como seria implementação disto no momento.

Essa função é utilizava no handle_newpoint e toda a lib de hashing que existe no outro arquivo são apenas maneiras bem eficientes de implementar o hash em si. A lógica de hashtable e o método de resolução de colisão (hashing duplo) estão nessa função.